### PR TITLE
Updated to new repo located a Github and updated to 0.30rc1

### DIFF
--- a/0.30rc1/Dockerfile
+++ b/0.30rc1/Dockerfile
@@ -16,7 +16,7 @@ RUN echo "deb http://ppa.launchpad.net/mc3man/trusty-media/ubuntu trusty main" \
   git
 
 ENV TAG 0.22
-RUN git clone https://bitbucket.org/ccrisan/motioneye.git /motioneye \
+RUN git clone https://github.com/ccrisan/motioneye /motioneye \
   && cd /motioneye \
   && git checkout tags/${TAG} \
   && cp /motioneye/settings_default.py /motioneye/settings.py

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -15,7 +15,7 @@ RUN echo "deb http://ppa.launchpad.net/mc3man/trusty-media/ubuntu trusty main" \
   v4l-utils \
   git
 
-RUN git clone https://bitbucket.org/ccrisan/motioneye.git /motioneye \
+RUN git clone https://github.com/ccrisan/motioneye /motioneye \
   && cp /motioneye/settings_default.py /motioneye/settings.py
   
 VOLUME ["/storage"]


### PR DESCRIPTION
The Bitbucket repo hasn't been updated in a while. Updated to their Github repo and updated tag to latest one available, 0.30rc1.
